### PR TITLE
Add support for deleteincompletescan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,74 +4,100 @@ This action runs the Veracode Java Wrapper's 'upload and scan' action.
 
 ## Inputs
 
-### `appname` 
+### `appname`
+
 **Required:** STRING - The application name.
 
 **Default:** '${{ github.repository }}'
 
 ### `createprofile`
+
 **Required:**  BOOLEAN - True to create a new application profile.
 
 **Default:** true
 
 ### `filepath`
+
 **Required:** STRING - Filepath or folderpath of the file or directory to upload. (If the last character is a backslash it needs to be escaped: \\\\).
 
 ### `version`
+
 **Required:** STRING - The name or version number of the new build.
 
 **Default:** 'Scan from Github job: ${{ github.run_id }}'
 
 ### `vid`
+
 **Required:** Veracode API ID.
 
 ### `vkey`
+
 **Required:** Veracode API key.
 
 ## Optional Inputs
 
 ### `createsandbox`
+
 **Optional** BOOLEAN - Set 'true' if the sandbox should be created on the Veracode platform
 
 ### `sandboxname`
+
 **Optional** STRING - The sandboxname inside the application profile name
 
 ### `scantimeout`
+
 **Optional** INTEGER - Number of minutes how long the action is waiting for the scan to complete. Use this to introduce break build functionality
 
 ### `exclude`
+
 **Optional** STRING - Exclude modules from modules selection / scanning. Case-sensitive, comma-separated list of module name patterns that represent the names of modules to not scan as top-level modules. The * wildcard matches 0 or more characters. The ? wildcard matches exactly one character.
 
 ### `include`
+
 **Optional** STRING - Include modules in modules selection / scanning. Case-sensitive, comma-separated list of module name patterns that represent the names of modules to scan as top-level modules. The * wildcard matches 0 or more characters. The ? wildcard matches exactly one character.
 
 ### `criticality`
+
 **Optional** STRING - Set the business criticality, autoamtically choosing the corresponding policy to rate findings. Options: VeryHigh, High, Medium, Low, VeryLow
 
 ### `pattern`
+
 **Optional** STRING - Case-sensitive filename pattern that represents the names of uploaded files to save with a different name. The * wildcard matches 0 or more characters. The ? wildcard matches exactly one character. Each wildcard corresponds to a numbered group that you can reference in the replacement pattern.
 
 ### `replacement`
+
 **Optional** STRING - Replacement pattern that references groups captured by the filename pattern. For example, if the filename pattern is --SNAPSHOT.war and the replacement pattern is $1-master-SNAPSHOT.war, an uploaded file named app-branch-SNAPSHOT.war is saved as app-master-SNAPSHOT.war.
 
 ### `sandboxid`
+
 **Optional** INTEGER - ID of the sandbox in which to run the scan.
 
 ### `scanallnonfataltoplevelmodules`
+
 **Optional** BOOLEAN - If this parameter is not set, the default is false. When set to true, if the application has more than one module, and at least one of the top-level modules does not have any fatal prescan errors, it starts the scan for those modules after prescan is complete.
 
 ### `selected`
+
 **Optional** BOOLEAN - Set this parameter to true to scan the modules currently selected in the Veracode Platform.
 
 ### `selectedpreviously`
+
 **Optional** BOOLEAN - Set to true to scan only the modules selected in the previous scan.
 
 ### `teams`
+
 **Optional** STRING - Required if you are creating a new application in the Veracode Platform. Comma-separated list of team names associated with the specified application.
 
 ### `toplevel`
+
 **Optional** BOOLEAN - When set to true, Veracode only scans the top-level modules in your files.
 Veracode recommends that you use the toplevel parameter if you want to ensure the scan completes even though there are non-fatal errors, such as unsupported frameworks.
+
+### `deleteIncompleteScan`
+
+**Optional** BOOLEAN - Set to true to automatically delete the current scan if there are any errors when uploading files or starting the scan. If the include or exclude parameters are set, this parameter deletes the scan if there are errors when starting the scan after module selection. Defaults to false.
+
+With the scan deleted automatically, you can create subsequent scans without having to manually delete an incomplete scan.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     description: 'replacement'
     required: false
   sandboxid:
-    description: 'replacement'
+    description: 'specify to scan in a sandbox'
     required: false
   scanallnonfataltoplevelmodules:
     description: 'All top level modules'
@@ -63,6 +63,9 @@ inputs:
     required: false
   toplevel:
     description: 'teams'
+    required: false
+  deleteincompletescan:
+    description: 'delete any incomplete scan in the application or sandbox before submitting'
     required: false
   
     
@@ -94,3 +97,4 @@ runs:
     - ${{ inputs.selectedpreviously }}
     - ${{ inputs.teams }}
     - ${{ inputs.toplevel }}
+    - ${{ inputs.deleteincompletescan }}

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     description: 'teams'
     required: false
   deleteincompletescan:
-    description: 'delete any incomplete scan in the application or sandbox before submitting'
+    description: 'automatically delete the current scan if there are any errors when uploading files or starting the scan'
     required: false
   
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -235,9 +235,7 @@ echo "        -createprofile \"$createprofile\"" >> runJava.sh
 
 
 #below pulls latest wrapper version. alternative is to pin a version like so:
-#javawrapperversion=21.4.7.5
-
-
+#javawrapperversion=21.5.7.7
 
 javawrapperversion=$(curl https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/maven-metadata.xml | grep latest |  cut -d '>' -f 2 | cut -d '<' -f 1)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -226,7 +226,7 @@ fi
 
 if [ "$deleteincompletescan" ]
 then
-    echo "        -deleteIncompleteScan \"$deleteincompletescan\" \\" >> runJava.sh
+    echo "        -deleteincompletescan \"$deleteincompletescan\" \\" >> runJava.sh
 fi
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ selected=${17}
 selectedpreviously=${18}
 teams=${19}
 toplevel=${20}
-
+deleteincompletescan=${21}
 
 
 
@@ -65,6 +65,7 @@ echo "selected: ${17}"
 echo "selectedpreviously: ${18}"
 echo "teams: ${19}"
 echo "toplevel: ${20}"
+echo "deleteincompletescan: ${21}"
 
 
 #Check if required parameters are set
@@ -223,7 +224,10 @@ then
         fi
 fi
 
-
+if [ "$deleteincompletescan" ]
+then
+    echo "        -deleteIncompleteScan \"$deleteincompletescan\" \\" >> runJava.sh
+fi
 
 
 echo "        -createprofile \"$createprofile\"" >> runJava.sh
@@ -231,7 +235,7 @@ echo "        -createprofile \"$createprofile\"" >> runJava.sh
 
 
 #below pulls latest wrapper version. alternative is to pin a version like so:
-#javawrapperversion=20.8.7.1
+#javawrapperversion=21.4.7.5
 
 
 


### PR DESCRIPTION
Added `deleteincompletescan` as an optional parameter for the action, bumped the commented out Java Wrapper version to the minimum that supports this action, and eliminated some Markdown linting warnings in the Readme.