### PR TITLE
Change default version to allow re-runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   version:  # id of input
     description: 'version'
     required: true
-    default: 'Scan from Github job: ${{ github.run_id }}'
+    default: 'Scan from Github job: ${{ github.run_id }}-${{ github.run_number }}'
   vid:  # id of input
     description: 'vid'
     required: true


### PR DESCRIPTION
I noticed an issue where re-running a job would fail with the message:
There is another scan with the name "Scan from Github job: 2004476215" for the same application.

This change adds the job run number to the default version value to prevent this scenario from occurring.