### PR TITLE
Update Readme.md to include May 4th changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 ### `deleteIncompleteScan`
 
-**Optional** Boolean - Set to true to automatically delete the current scan if there are any errors when uploading files or starting the scan. If the include or exclude parameters are set, this parameter deletes the scan if there are errors when starting the scan after module selection. Defaults to false.
+**Optional**
 
 **In Java API Wrapper version >=22.5.10.0 this parameter has changed to an Integer. One of these values:**
 * 0: do not delete an incomplete scan when running the uploadandscan action. The default. If set, you must delete an incomplete scan manually to proceed with the uploadandscan action.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 ### `deleteIncompleteScan`
 
-**Optional** BOOLEAN - Set to true to automatically delete the current scan if there are any errors when uploading files or starting the scan. If the include or exclude parameters are set, this parameter deletes the scan if there are errors when starting the scan after module selection. Defaults to false.
+**Optional** Boolean - Set to true to automatically delete the current scan if there are any errors when uploading files or starting the scan. If the include or exclude parameters are set, this parameter deletes the scan if there are errors when starting the scan after module selection. Defaults to false.
+
+**In Java API Wrapper version >=22.5.10.0 this parameter has changed to an Integer. One of these values:**
+* 0: do not delete an incomplete scan when running the uploadandscan action. The default. If set, you must delete an incomplete scan manually to proceed with the uploadandscan action.
+* 1: delete a scan with a status of incomplete, no modules defined, failed, or canceled to proceed with the uploadandscan action. If errors occur when running this action, the Java wrapper automatically deletes the incomplete scan.
+* 2: delete a scan of any status except Results Ready to proceed with the uploadandscan action. If errors occur when running this action, the Java wrapper automatically deletes the incomplete scan.
+
 
 With the scan deleted automatically, you can create subsequent scans without having to manually delete an incomplete scan.
 


### PR DESCRIPTION
Veracode pushed an update on May 4th changing the implementation of -deleteincompletescan . The change was not backwards compatible.

Veracode Notes:

Java API Wrapper version 22.5.10.0 includes changes to the -deleteincompletescan parameter for deleting incomplete scans when running the uploadandscan action. This parameter now accepts an integer value, rather than boolean, for deleting an incomplete scan based on the scan status.

Note: These changes are not backward compatible with the -deleteincompletescan parameter available in earlier versions of the Java API Wrapper. If you currently use this parameter, after upgrading the wrapper you must change the value from boolean to one of the accepted integer values.