### PR TITLE
Fix #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+runJava.sh
+VeracodeJavaAPI.jar

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ With the scan deleted automatically, you can create subsequent scans without hav
 
 ### `javawrapperversion`
 
-**Optional** STRING - Allows specifying the version of the Java API Wrapper used by the script to call the Veracode APIs. The default is to use the latest released version of the Veracode Java API Wrapper, as [published in Maven Central](https://search.maven.org/search?q=a:vosp-api-wrappers-java).
+**Optional** STRING - Allows specifying the version of the Java API Wrapper used by the script to call the Veracode APIs. The default is to use the latest released version of the Veracode Java API Wrapper, as [published in Maven Central](https://search.maven.org/search?q=a:vosp-api-wrappers-java). An example of the version string format is `22.5.10.1`.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 With the scan deleted automatically, you can create subsequent scans without having to manually delete an incomplete scan.
 
+### `javawrapperversion`
+
+**Optional** STRING - Allows specifying the version of the Java API Wrapper used by the script to call the Veracode APIs. The default is to use the latest released version of the Veracode Java API Wrapper, as [published in Maven Central](https://search.maven.org/search?q=a:vosp-api-wrappers-java).
+
 ## Example usage
 
 The following example will upload all files contained within the folder_to_upload to Veracode and start a static scan.

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,9 @@ inputs:
   deleteincompletescan:
     description: 'automatically delete the current scan if there are any errors when uploading files or starting the scan'
     required: false
+  javawrapperversion:
+    description: 'specify version of the Java API Wrapper; default is latest'
+    required: false 
   
     
  
@@ -98,3 +101,4 @@ runs:
     - ${{ inputs.teams }}
     - ${{ inputs.toplevel }}
     - ${{ inputs.deleteincompletescan }}
+    - ${{ inputs.javawrapperversion }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,7 @@ selectedpreviously=${18}
 teams=${19}
 toplevel=${20}
 deleteincompletescan=${21}
-
-
+javawrapperversion=${22}
 
 
 echo "Required Information"
@@ -232,14 +231,14 @@ fi
 
 echo "        -createprofile \"$createprofile\"" >> runJava.sh
 
+if [ "$javawrapperversion" ]
+then 
+    javawrapperversion=$javawrapperversion
+else #fetch latest wrapper version from Maven
+    javawrapperversion=$(curl https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/maven-metadata.xml | grep latest |  cut -d '>' -f 2 | cut -d '<' -f 1)
+fi 
 
-
-#below pulls latest wrapper version. alternative is to pin a version like so:
-#javawrapperversion=21.5.7.7
-
-javawrapperversion=$(curl https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/maven-metadata.xml | grep latest |  cut -d '>' -f 2 | cut -d '<' -f 1)
-
-#echo "javawrapperversion: $javawrapperversion"
+echo "javawrapperversion: $javawrapperversion"
 
 curl -sS -o VeracodeJavaAPI.jar "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$javawrapperversion/vosp-api-wrappers-java-$javawrapperversion.jar"
 chmod 777 runJava.sh


### PR DESCRIPTION
Add parameter `javawrapperversion` to allow customers to pin to a particular version of the wrapper. Parameter is optional; pulls latest when no value is specified.