### PR TITLE
Updated default value for 'version' parameter.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   version:  # id of input
     description: 'version'
     required: true
-    default: 'Scan from Github job: ${{ github.run_id }}-${{ github.run_number }}'
+    default: 'Scan from Github job: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}'
   vid:  # id of input
     description: 'vid'
     required: true


### PR DESCRIPTION
Both `github.run_id` and `github.run_number` do not change values when a workflow is re-run. So if that occurs, we end up creating a scan with the same name on the Veracode platform as the previous run, and the workflow fails. Adding `github.run_attempt` ensures that the version/scan name is unique across each run, as it does increment per run.