### PR TITLE
add maxretrycount parameter, default to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 **Optional** BOOLEAN - Set to true to show detailed diagnostic information, which you can use for debugging, in the output.
 
+### `maxretrycount`
+
+**Optional** INTEGER - Number of times to retry the last request during certain error conditions or when a request times out. Value range is 1 to 5. Default is 5
+
 ## Examples
 
 ### General Usage

--- a/action.yml
+++ b/action.yml
@@ -79,8 +79,12 @@ inputs:
   includenewmodules:
     description: 'automatically select all new top-level modules for inclusion in the scan'
     required: false  
-    
- 
+  maxretrycount:
+    description: 'Number of times to retry the last request during certain error conditions or when a request times out. Value range is 1 to 5.'
+    required: false
+    default: 5
+
+
 # outputs:
 #   time: # id of output
 #     description: 'The time we greeted you'
@@ -113,3 +117,4 @@ runs:
     - ${{ inputs.javawrapperversion }}
     - ${{ inputs.debug }}
     - ${{ inputs.includenewmodules }}
+    - ${{ inputs.maxretrycount }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ scanpollinginterval=${22}
 javawrapperversion=${23}
 debug=${24}
 includenewmodules=${25}
+maxretrycount=${26}
 
 
 echo "Required Information"
@@ -72,6 +73,7 @@ echo "scanpollinginterval: ${22}"
 echo "javawrapperversion: ${23}"
 echo "debug: ${24}"
 echo "includenewmodules: ${25}"
+echo "maxretrycount: ${26}"
 
 
 #Check if required parameters are set
@@ -261,6 +263,11 @@ fi
 if [ "$includenewmodules" ] #
 then
     echo "        -includenewmodules \"$includenewmodules\"" >> runJava.sh
+fi
+
+if [ "$maxretrycount" ]
+then
+    echo "        -maxretrycount \"$maxretrycount\"" >> runJava.sh
 fi
 
 curl -sS -o VeracodeJavaAPI.jar "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$javawrapperversion/vosp-api-wrappers-java-$javawrapperversion.jar"


### PR DESCRIPTION
This Pull Request adds maxretrycount parameter and defaults to 5 to work around intermittent network-related issues.

```
[2023.07.05 17:37:34.648] Transaction ID: [052f506d-1d22-47c6-803b-8fb09adb4e2d]
[2023.07.05 17:37:37.197] Do retry #1 out of 5 attempts for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:39.345] Do retry #2 out of 5 attempts for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:41.457] Do retry #3 out of 5 attempts for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:43.553] Do retry #4 out of 5 attempts for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:45.676] Do retry #5 out of 5 attempts for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:45.771] 
[2023.07.05 17:37:45.771] Server returned HTTP response code: 401 for URL: https://analysiscenter.veracode.com/api/5.0/getapplist.do
[2023.07.05 17:37:45.772] Please make sure that all of the following are true: 
[2023.07.05 17:37:45.772] 1. The login credentials are valid.
[2023.07.05 17:37:45.772] 2. The account is an API account with sufficient privilege.
[2023.07.05 17:37:45.772] 3. The account is not locked.
[2023.07.05 17:37:45.772] 4. This machine's internet-facing IP address is not restricted.
[2023.07.05 17:37:45.772] 5. Check if the system time is synchronized with the NTP server.
[2023.07.05 17:37:45.772] 
```