### PR TITLE
do not hide API ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         appname: '${{ github.repository }}'
         version: '${{ github.run_id }}'
         filepath: 'binaries_to_upload/*.jar'
-        vid: '${{ secrets.VERACODE_API_ID }}'
+        vid: '${{ vars.VERACODE_API_ID }}'
         vkey: '${{ secrets.VERACODE_API_KEY }}'
         createsandbox: true
         sandboxname: 'Github - ${{ github.ref }}'

--- a/.github/workflows/policyscan.yml
+++ b/.github/workflows/policyscan.yml
@@ -36,6 +36,6 @@ jobs:
           appname: '${{ github.repository }}'
           version: '${{ github.run_id }}'
           filepath: 'project.zip'
-          vid: '${{ secrets.VERACODE_API_ID }}'
+          vid: '${{ vars.VERACODE_API_ID }}'
           vkey: '${{ secrets.VERACODE_API_KEY }}'
           scantimeout: 15

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ echo "filepath: $filepath"
 echo "version: $version"
 if [ "$vid" ]
 then
-echo "vid: ***"
+echo "vid: $vid"
 else
 echo "vid:"
 fi


### PR DESCRIPTION
This pull requests logs API ID (`vid`) parameter in order to simplify troubleshooting of common authentication and access issues.

VERACODE_API_ID in example workflows `main.yml` and `policyscan.yml` are moved from secrets to variables.

```
Required Information
====================
appname: swiewiora/veracode-uploadandscan-action
createprofile: false
filepath: binaries_to_upload/*.jar
version: 5467649408
vid: ceabac4a1736896a699eb5537ab658af
vkey: ***
```
...
```
java -jar VeracodeJavaAPI.jar \
        -filepath binaries_to_upload/*.jar \
        -version "5467649408" \
        -action "uploadandscan" \
        -appname "swiewiora/veracode-uploadandscan-action" \
        -vid "ceabac4a1736896a699eb5537ab658af" \
        -vkey "***" \
        -createsandbox="true" \
        -sandboxname "Github - refs/heads/fix/vid" \
        -scantimeout "15" \
        -autoscan "true" \
        -criticality "VeryHigh" \
        -createprofile "false" \
```