### PR TITLE
Added Policy Parameter for Create Profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@Latest
     - uses: actions/setup-java@v2
       with: 
         distribution: 'adopt'
         java-version: '8'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@Latest
       with:
         path: binaries_to_upload/*.jar
     - name: Veracode Upload and Scan Action Step

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,5 @@ jobs:
         sandboxname: 'Github - ${{ github.ref }}'
         scantimeout: 15
         criticality: 'VeryHigh'
-        createprofile: false
+        createprofile: true
+        policy: 'Test policy 2'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@Latest
+    - uses: actions/checkout@v3
     - uses: actions/setup-java@v2
       with: 
         distribution: 'adopt'
         java-version: '8'
-    - uses: actions/upload-artifact@Latest
+    - uses: actions/upload-artifact@v4.6.2
       with:
         path: binaries_to_upload/*.jar
     - name: Veracode Upload and Scan Action Step

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 **Optional** INTEGER - Number of times to retry the last request during certain error conditions or when a request times out. Value range is 1 to 5. Default is 5
 
+### `policy` 
+
+**Optional** STRING - The policy name that matches the policy in the Veracode platform you want to assign to the application profile on creation. Default is '' and the [`criticality`]("### `criticality`") will be used.
+
 ## Examples
 
 ### General Usage

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Veracode recommends that you use the toplevel parameter if you want to ensure th
 
 ### `policy` 
 
-**Optional** STRING - The policy name that matches the policy in the Veracode platform you want to assign to the application profile on creation. Default is '' and the [`criticality`]("### `criticality`") will be used.
+**Optional** STRING - The policy name that matches the policy in the Veracode platform you want to assign to the application profile on creation. Default is '' and the [`criticality`](README.md#criticality) will be used.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -122,3 +122,4 @@ runs:
     - ${{ inputs.debug }}
     - ${{ inputs.includenewmodules }}
     - ${{ inputs.maxretrycount }}
+    - ${{ inputs.policy }}

--- a/action.yml
+++ b/action.yml
@@ -46,10 +46,6 @@ inputs:
   replacement:
     description: 'replacement'
     required: false
-   policy:
-    description: 'Veracode Policy Name'
-    required: false
-    default: ''
   sandboxid:
     description: 'specify to scan in a sandbox'
     required: false
@@ -87,6 +83,10 @@ inputs:
     description: 'Number of times to retry the last request during certain error conditions or when a request times out. Value range is 1 to 5.'
     required: false
     default: 5
+  policy:
+    description: 'Veracode Policy Name'
+    required: false
+    default: ''
 
 
 # outputs:

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
   replacement:
     description: 'replacement'
     required: false
+   policy:
+    description: 'Veracode Policy Name'
+    required: false
+    default: ''
   sandboxid:
     description: 'specify to scan in a sandbox'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -l
+parameters=[ appname, createprofile, filepath, version, vid, vkey, createsandbox, sandboxname, scantimeout,exclude, include, criticality, pattern, replacement, sandboxid,scanallnonfataltoplevelmodules,selected,selectedpreviously, teams, toplevel, deleteincompletescan, scanpollinginterval, javawrapperversion, debug, includenewmodules, maxretrycount, policy]
 
 #required parameters
 appname=$1
@@ -30,7 +31,7 @@ javawrapperversion=${23}
 debug=${24}
 includenewmodules=${25}
 maxretrycount=${26}
-
+policy=${27}
 
 echo "Required Information"
 echo "===================="
@@ -38,14 +39,15 @@ echo "appname: $appname"
 echo "createprofile: $createprofile"
 echo "filepath: $filepath"
 echo "version: $version"
-if [ "$vid" ]
+#echo "policy: $policy" 
+if [ "$vid"  || "${5}" ]
 then
 echo "vid: ***"
 else
 echo "vid:"
 fi
 
-if [ "$vkey" ]
+if [ "$vkey" || "${6}" ]
 then
 echo "vkey: ***"
 else
@@ -54,9 +56,9 @@ fi
 echo ""
 echo "Optional Information"
 echo "===================="
-echo "createsandbox: $createsandbox"
-echo "sandboxname: $8"
-echo "scantimeout: $9"
+echo "createsandbox: ${7}" #createsandbox" # why is this in a differnt convention ? 
+echo "sandboxname: ${8}"
+echo "scantimeout: ${9}"
 echo "exclude: ${10}"
 echo "include: ${11}"
 echo "criticality: ${12}"
@@ -74,6 +76,7 @@ echo "javawrapperversion: ${23}"
 echo "debug: ${24}"
 echo "includenewmodules: ${25}"
 echo "maxretrycount: ${26}"
+echo "policy: ${27}"
 
 
 #Check if required parameters are set
@@ -270,7 +273,12 @@ then
     echo "        -maxretrycount \"$maxretrycount\" \\" >> runJava.sh
 fi
 
+if [ "$policy" ]
+then
+    echo "        -policy \"$policy\" \\" >> runJava.sh
+fi
+
 curl -sS -o VeracodeJavaAPI.jar "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$javawrapperversion/vosp-api-wrappers-java-$javawrapperversion.jar"
-chmod 777 runJava.sh
-cat runJava.sh
+chmod 777 runJava.sh # does it need full 7 ? 
+cat runJava.sh        
 ./runJava.sh


### PR DESCRIPTION
# Changes # 

- updated the upload-artifact and download-artifact actions to v4 versions per deprecation
- added policy parameter to the list of parameters to be passed to allow for policy assignment at the time of application creation
- conformed bash entry point to best practices.
- updated main workflow to test with application profile creation set to true and a policy set to `Test Policy 2`
[![CI](https://github.com/bnreplah/veracode-uploadandscan-action/actions/workflows/main.yml/badge.svg)](https://github.com/bnreplah/veracode-uploadandscan-action/actions/workflows/main.yml)
![image](https://github.com/user-attachments/assets/bf664848-46c7-4f77-89ff-6aeea292d331)
