### PR TITLE
Fix Docker build failure by replacing deprecated openjdk:latest base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM openjdk:latest
+FROM eclipse-temurin:latest
     
 #RUN yum install curl
 


### PR DESCRIPTION
## Problem
The action fails to build because `openjdk:latest` Docker image has been deprecated and removed from Docker Hub, causing the following error:
```
manifest for openjdk:latest not found: manifest unknown: manifest unknown
```

## Solution
Replace `openjdk:latest` with `eclipse-temurin:latest`, which is:
- Actively maintained by Eclipse Adoptium
- The recommended replacement for deprecated OpenJDK images
- Fully compatible with existing functionality

## Related Issue
Fixes #50 